### PR TITLE
Fix override example

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ In it, write the following:
 	  node-app:
 	    build: app
 	    environment:
-        APP_ENVIRONMENT: 'Default'
+	      APP_ENVIRONMENT: 'Default'
 
 
 Save this file, and create `docker-compose.override.yml` in the same directory with the following contents:


### PR DESCRIPTION
The docker-compose file at the override example is wrongly formatted at the APP_ENVIRONMENT property. If you would copy the example and run `docker-compose up`,  following error would be thrown:
```batch
Unsupported config option for services.node-app: 'APP_ENVIRONMENT'
```